### PR TITLE
Feat Adds earthly as CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
     name: linter
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         elixir:
           - "1.9.2-erlang-22.3.4.16-alpine-3.13.1"
@@ -19,16 +20,15 @@ jobs:
       - name: test elixir linters
         run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixir}} +setup-linters
   test-neo4j:
-    name: linter
+    name: neo4j
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         elixir:
-          - "1.9.2-erlang-22.3.4.16-alpine-3.13.1"
           - "1.12.0-rc.1-erlang-24.0-alpine-3.13.3"
         neo4j:
           - "4.1"
-          - "4.2"
           - "4.2.5"
     steps:
       - uses: earthly/actions/setup-earthly@v1
@@ -36,4 +36,4 @@ jobs:
           version: v0.5.10
       - uses: actions/checkout@v2
       - name: tests
-        run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixir}} +test-neo4ecto
+        run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixir}} NEO4J=${{matrix.neo4j}} +test-neo4ecto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
           version: v0.5.10
       - uses: actions/checkout@v2
       - name: tests
-        run: earthly -P --ci --build-arg ELIXIR_BASE=1.12.0-rc.1-erlang-24.0-alpine-3.13.3 --build-arg NEO4J=neo4j/neo4j-arm64-experimental:4.2.5-arm64 +test-neo4ecto
+        run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixir}} --build-arg NEO4J=${{matrix.neo4j}} +test-neo4ecto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
         elixir:
           - "1.12.0-rc.1-erlang-24.0-alpine-3.13.3"
         neo4j:
-          - "4.1"
-          - "4.2.5"
+          - "neo4j:4.1"
+          - "neo4j:4.2.5"
     steps:
       - uses: earthly/actions/setup-earthly@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,28 +3,37 @@ on: [push]
 
 jobs:
   test:
+    name: linter
     runs-on: ubuntu-18.04
-    services:
-      neo4j:
-        image: neo4j:4.2
-        ports: ["7687:7687"]
-        env:
-          NEO4J_ACCEPT_LICENSE_AGREEMENT: yes
-          NEO4J_AUTH: none
-        options: >-
-          --health-cmd "cypher-shell -u neo4j -p test 'RETURN 1'"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-start-period 10s
-          --health-retries 5
+    strategy:
+      matrix:
+        elixir:
+          - "1.9.2-erlang-22.3.4.16-alpine-3.13.1"
+          - "1.12.0-rc.1-erlang-24.0-alpine-3.13.3"
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1
+      - uses: earthly/actions/setup-earthly@v1
         with:
-          otp-version: "24.0-rc2"
-          elixir-version: "1.12.0-rc.0"
-      - run: mix deps.get --only test
-      - run: mix compile --warnings-as-errors
-      - run: mix format --check-formatted
-      - run: mix credo --strict
-      - run: mix test --trace --raise
+          version: v0.5.10
+      - uses: actions/checkout@v2
+      - name: test ectl_sql
+        run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixir}} +setup-linters
+  test-neo4j:
+    name: linter
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        elixir:
+          - "1.9.2-erlang-22.3.4.16-alpine-3.13.1"
+          - "1.12.0-rc.1-erlang-24.0-alpine-3.13.3"
+        neo4j:
+          - "4.1"
+          - "4.2"
+          - "4.2.5"
+    steps:
+      - uses: earthly/actions/setup-earthly@v1
+        with:
+          version: v0.5.10
+      - uses: actions/checkout@v2
+      - name: test ectl_sql
+        run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixir}} +test-neo4ecto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
           version: v0.5.10
       - uses: actions/checkout@v2
       - name: tests
-        run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixir}} NEO4J=${{matrix.neo4j}} +test-neo4ecto
+        run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixir}} --build-arg NEO4J=${{matrix.neo4j}} +test-neo4ecto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           version: v0.5.10
       - uses: actions/checkout@v2
-      - name: test ectl_sql
+      - name: test elixir linters
         run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixir}} +setup-linters
   test-neo4j:
     name: linter
@@ -35,5 +35,5 @@ jobs:
         with:
           version: v0.5.10
       - uses: actions/checkout@v2
-      - name: test ectl_sql
+      - name: tests
         run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixir}} +test-neo4ecto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
           version: v0.5.10
       - uses: actions/checkout@v2
       - name: tests
-        run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixir}} --build-arg NEO4J=${{matrix.neo4j}} +test-neo4ecto
+        run: earthly -P --ci --build-arg ELIXIR_BASE=1.12.0-rc.1-erlang-24.0-alpine-3.13.3 --build-arg NEO4J=neo4j/neo4j-arm64-experimental:4.2.5-arm64 +test-neo4ecto

--- a/Earthfile
+++ b/Earthfile
@@ -32,15 +32,15 @@ test:
 
 test-neo4ecto:
     FROM +test
-    ARG NEO4J="neo4j-arm64-experimental:4.2.5-arm64"
+    ARG NEO4J="neo4j/neo4j-arm64-experimental:4.2.5-arm64"
     WITH DOCKER \
-        --pull "neo4j/$NEO4J"
+        --pull "$NEO4J"
         RUN docker run --name neo4j --network=host -d -p 7687:7687 -e 'NEO4J_AUTH=none' \
                 --health-cmd="cypher-shell -u neo4j -p test 'RETURN 1'" \ 
                 --health-interval=10s \
                 --health-timeout=5s \ 
                 --health-start-period=10s \
                 --health-retries=5 \
-            "neo4j/$NEO4J"; \
+            "$NEO4J"; \
             mix test --trace --raise --include skip;
     END

--- a/Earthfile
+++ b/Earthfile
@@ -25,7 +25,7 @@ test:
     FROM +setup-base
     COPY --dir lib test ./
     RUN MIX_ENV=test mix deps.compile
-    RUN mix deps.get --only test && mix deps.unlock --check-unused
+    RUN mix deps.get --only test
     RUN mix deps.compile
     RUN mix compile --warnings-as-errors
 

--- a/Earthfile
+++ b/Earthfile
@@ -36,7 +36,7 @@ test-neo4ecto:
     ARG NEO4J="neo4j/neo4j-arm64-experimental:4.2.5-arm64"
     WITH DOCKER \
         --pull "$NEO4J"
-        RUN docker run --name neo4j --network=host -d -p 7687:7687 -e 'NEO4J_AUTH=none' \
+        RUN docker run --name neo4j --network=host -d -p 7687:7687 -e "NEO4J_AUTH=none" \
                 --health-cmd="cypher-shell -u neo4j -p test 'RETURN 1'" \ 
                 --health-interval=10s \
                 --health-timeout=5s \ 

--- a/Earthfile
+++ b/Earthfile
@@ -38,10 +38,10 @@ test-neo4ecto:
         --pull "$NEO4J"
         RUN docker run --name neo4j --network=host -d -p 7687:7687 --env NEO4J_AUTH=none \
                 --health-cmd="cypher-shell -u neo4j -p test 'RETURN 1'" \ 
-                --health-interval=10s \
-                --health-timeout=5s \ 
-                --health-start-period=10s \
-                --health-retries=5 \
+                --health-interval=5s \
+                --health-timeout=1s \ 
+                --health-start-period=5s \
+                --health-retries=15 \
             "$NEO4J"; \
             mix test --trace --raise;
     END

--- a/Earthfile
+++ b/Earthfile
@@ -42,5 +42,5 @@ test-neo4ecto:
                 --health-start-period=10s \
                 --health-retries=5 \
             "$NEO4J"; \
-            mix test --trace --raise --include skip;
+            mix test --trace --raise;
     END

--- a/Earthfile
+++ b/Earthfile
@@ -36,12 +36,11 @@ test-neo4ecto:
     ARG NEO4J="neo4j/neo4j-arm64-experimental:4.2.5-arm64"
     WITH DOCKER \
         --pull "$NEO4J"
-        RUN docker run --name neo4j --network=host -d -p 7687:7687 --env NEO4J_AUTH=none \
-                --health-cmd="cypher-shell -u neo4j -p test 'RETURN 1'" \ 
-                --health-interval=10s \
-                --health-timeout=5s \ 
-                --health-start-period=10s \
-                --health-retries=15 \
-            "$NEO4J"; \
-            mix test --trace --raise;
+         RUN docker run --name neo4j --network=host -d -p 7687:7687 --env NEO4J_AUTH=none "$NEO4J"; \
+        while ! docker exec neo4j bash -c "cypher-shell -u neo4j -p test 'RETURN 1'"; do \
+            test "$(date +%s)" -le "$timeout" || (echo "timed out waiting for neo4j"; exit 1); \
+            echo "waiting for neo4j"; \
+            sleep 1; \
+        done; \
+        mix test --trace --raise;
     END

--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,46 @@
+
+setup-elixir:
+    ARG ELIXIR_BASE=1.12.0-rc.1-erlang-24.0-alpine-3.13.3
+    FROM hexpm/elixir:$ELIXIR_BASE
+    RUN apk add --no-progress --update git build-base
+    ENV ELIXIR_ASSERT_TIMEOUT=10000
+ 
+
+setup-base:
+    FROM +setup-elixir
+    COPY mix.exs .
+    COPY mix.lock .
+    COPY .formatter.exs .
+    RUN mix local.rebar --force
+    RUN mix local.hex --force
+    RUN mix deps.get
+
+setup-linters:
+    FROM +setup-base
+    RUN mix compile --warnings-as-errors
+    RUN mix format --check-formatted
+    RUN mix credo --strict
+
+test:
+    FROM +setup-base
+    COPY --dir lib test ./
+    RUN MIX_ENV=test mix deps.compile
+    RUN mix deps.get --only test && mix deps.unlock --check-unused
+    RUN mix deps.compile
+    RUN mix compile --warnings-as-errors
+
+
+test-neo4ecto:
+    FROM +test
+    ARG NEO4J="neo4j-arm64-experimental:4.2.5-arm64"
+    WITH DOCKER \
+        --pull "neo4j/$NEO4J"
+        RUN docker run --name neo4j --network=host -d -p 7687:7687 -e 'NEO4J_AUTH=none' \
+                --health-cmd="cypher-shell -u neo4j -p test 'RETURN 1'" \ 
+                --health-interval=10s \
+                --health-timeout=5s \ 
+                --health-start-period=10s \
+                --health-retries=5 \
+            "neo4j/$NEO4J"; \
+            mix test --trace --raise --include skip;
+    END

--- a/Earthfile
+++ b/Earthfile
@@ -4,6 +4,7 @@ setup-elixir:
     FROM hexpm/elixir:$ELIXIR_BASE
     RUN apk add --no-progress --update git build-base
     ENV ELIXIR_ASSERT_TIMEOUT=10000
+    RUN apk add --no-progress --update docker docker-compose
  
 
 setup-base:

--- a/Earthfile
+++ b/Earthfile
@@ -36,7 +36,7 @@ test-neo4ecto:
     ARG NEO4J="neo4j/neo4j-arm64-experimental:4.2.5-arm64"
     WITH DOCKER \
         --pull "$NEO4J"
-        RUN docker run --name neo4j --network=host -d -p 7687:7687 -e "NEO4J_AUTH=none" \
+        RUN docker run --name neo4j --network=host -d -p 7687:7687 --env NEO4J_AUTH=none \
                 --health-cmd="cypher-shell -u neo4j -p test 'RETURN 1'" \ 
                 --health-interval=10s \
                 --health-timeout=5s \ 

--- a/Earthfile
+++ b/Earthfile
@@ -38,9 +38,9 @@ test-neo4ecto:
         --pull "$NEO4J"
         RUN docker run --name neo4j --network=host -d -p 7687:7687 --env NEO4J_AUTH=none \
                 --health-cmd="cypher-shell -u neo4j -p test 'RETURN 1'" \ 
-                --health-interval=5s \
-                --health-timeout=1s \ 
-                --health-start-period=5s \
+                --health-interval=10s \
+                --health-timeout=5s \ 
+                --health-start-period=10s \
                 --health-retries=15 \
             "$NEO4J"; \
             mix test --trace --raise;

--- a/Earthfile
+++ b/Earthfile
@@ -22,7 +22,7 @@ setup-linters:
     RUN mix format --check-formatted
     RUN mix credo --strict
 
-test:
+test-setup:
     FROM +setup-base
     COPY --dir lib test ./
     RUN MIX_ENV=test mix deps.compile
@@ -32,13 +32,12 @@ test:
 
 
 test-neo4ecto:
-    FROM +test
+    FROM +test-setup
     ARG NEO4J="neo4j/neo4j-arm64-experimental:4.2.5-arm64"
     WITH DOCKER \
         --pull "$NEO4J"
          RUN docker run --name neo4j --network=host -d -p 7687:7687 --env NEO4J_AUTH=none "$NEO4J"; \
         while ! docker exec neo4j bash -c "cypher-shell -u neo4j -p test 'RETURN 1'"; do \
-            test "$(date +%s)" -le "$timeout" || (echo "timed out waiting for neo4j"; exit 1); \
             echo "waiting for neo4j"; \
             sleep 1; \
         done; \

--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ Pull requests are welcome. For major changes, please open an issue first to disc
 
 Please make sure to update tests as appropriate.
 
+## Running containerized tests with Earthly
+
+It is also possible to run tests under a containerized environment using [earthly](https://earthly.dev/get-earthly):
+
+    $ earthly -P +setup-linters
+    $ earthly -P +test-neo4ecto
+
+You can also use this to interactively debug any tests with diferent images of Neo4j and Elixir.
+
+    $ earthly -P -i --build-arg ELIXIR_BASE=1.12.0-rc.1-erlang-24.0-alpine-3.13.3 +setup-linter
+    $ earthly -P -i --build-arg ELIXIR_BASE=1.8.2-erlang-20.3.8.26-alpine-3.11.6 --build-arg NEO4J=4.1 +test-neo4ecto
+
+
 ## Copyright and License
 
 The source code is under the Apache 2 License.

--- a/lib/neo4_ecto.ex
+++ b/lib/neo4_ecto.ex
@@ -87,7 +87,6 @@ defmodule Neo4Ecto do
   @impl Ecto.Adapter
   def init(opts) do
     config = opts || neo4j_url()
-    IO.inspect config
     {:ok, Sips.child_spec(config), %{}}
   end
 

--- a/lib/neo4_ecto.ex
+++ b/lib/neo4_ecto.ex
@@ -87,7 +87,7 @@ defmodule Neo4Ecto do
   @impl Ecto.Adapter
   def init(opts) do
     config = opts || neo4j_url()
-
+    IO.inspect config
     {:ok, Sips.child_spec(config), %{}}
   end
 


### PR DESCRIPTION
This pull request adds Earthly to CI pipelines so that not only we can run parallel tests on CI, we also are able to run those tests locally.